### PR TITLE
`require` wasm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,32 @@ const decompressedBytes = decompress(compressedBytes, outputBytes);
 
 ## Using the module in a browser
 
-Emscripten compiled WebAssembly modules are built in 2 parts: a `.js` side and a `.wasm` side.  In the browser the `.js` side needs to download the `.wasm` side from the server so it can compile it.  There is [more information available in the emscripten documentation](https://kripken.github.io/emscripten-site/docs/compiling/Deploying-Pages.html).  When loading the module in the browser via webpack you need to make sure your sever will send the `.wasm` part of the module to the browser when the `.js` side of the module requests it.
+Emscripten compiled WebAssembly modules are built in 2 parts: a `.js` side and a `.wasm` side.  In the browser the `.js` side needs to download the `.wasm` side from the server so it can compile it.  There is [more information available in the emscripten documentation](https://kripken.github.io/emscripten-site/docs/compiling/Deploying-Pages.html).
+
+### Usage with Webpack
+
+We require the `wasm-lz4.wasm` module in our `locateFile` definition, so that module bundling with dynamic paths is possible. So if you are using Webpack, you can add the following entry:
+
+```
+...
+rules : [
+  ...
+  {
+    test: /\.wasm$/,
+    type: "javascript/auto",
+    use: {
+      loader: "file-loader",
+      options: {
+        name: "[name]-[hash].[ext]",
+      },
+    },
+  },
+  ...
+]
+...
+ ```
+
+The `javascript/auto` type setting tells Webpack to bypass its default importing logic, and just import the file as-is. Hopefully this hack will go away with improved WebAssembly support in webpack.
 
 ## Asynchronous loading & compiling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-lz4",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-lz4",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "main": "index.js",
   "license": "Apache-2.0",
   "repository": "cruise-automation/wasm-lz4",

--- a/pre.js
+++ b/pre.js
@@ -8,6 +8,7 @@
 // which gives us the opportunity to override the module resolution behavior in node
 
 var nodePath;
+var WASM_PATH = require("./wasm-lz4.wasm");
 
 if (typeof process !== "undefined") {
   Module["ENVIRONMENT"] = process.env.WASM_LZ4_ENVIRONMENT;
@@ -22,6 +23,7 @@ if (ENVIRONMENT_IS_NODE) {
   existingUncaughtListeners = process.listeners("unhandledRejection") || [];
 }
 
+
 // do some manipulating of the input file path
 // when running in node so the file is resolved
 // relative to the module root. by default its resolved to `wasm-lz4.wasm`
@@ -35,7 +37,11 @@ Module.locateFile = function(input) {
       }
     };
     // return the full resolved path to the input file
-    return __dirname + "/" + input;
+    return __dirname +  "/" + input;
   }
+  if (input.endsWith(".wasm")) {
+    return WASM_PATH;
+  }
+
   return input;
 };

--- a/pre.js
+++ b/pre.js
@@ -8,7 +8,6 @@
 // which gives us the opportunity to override the module resolution behavior in node
 
 var nodePath;
-var WASM_PATH = require("./wasm-lz4.wasm");
 
 if (typeof process !== "undefined") {
   Module["ENVIRONMENT"] = process.env.WASM_LZ4_ENVIRONMENT;
@@ -40,7 +39,9 @@ Module.locateFile = function(input) {
     return __dirname +  "/" + input;
   }
   if (input.endsWith(".wasm")) {
-    return WASM_PATH;
+    // Dynamically required if running in a web context.
+    const wasm_path = require("./wasm-lz4.wasm");
+    return wasm_path;
   }
 
   return input;


### PR DESCRIPTION
## Summary 

The previous `locateFile` implementation is not tuned for module bundlers like Webpack. If we require the module, as a way of explicitly identifying where the resource is located, we can configure our bundlers to actually pull in the `.wasm` resource into builds. 

Note: I bumped to a major version as this change will definitely break any apps that are pulling in the `.wasm` module the old way (i.e. if their bundling configs can't handle `.wasm` extensions).

## Testing

Tested locally with webviz.