### PR TITLE
Update header from GM Cruise LLC to Cruise LLC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-#  Copyright (c) 2018-present, GM Cruise LLC
+#  Copyright (c) 2018-present, Cruise LLC
 #
 #  This source code is licensed under the Apache License, Version 2.0,
 #  found in the LICENSE file in the root directory of this source tree.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-present, GM Cruise LLC
+//  Copyright (c) 2018-present, Cruise LLC
 //
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.

--- a/post.js
+++ b/post.js
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-present, GM Cruise LLC
+//  Copyright (c) 2018-present, Cruise LLC
 //
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.

--- a/pre.js
+++ b/pre.js
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-present, GM Cruise LLC
+//  Copyright (c) 2018-present, Cruise LLC
 //
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-present, GM Cruise LLC
+//  Copyright (c) 2018-present, Cruise LLC
 //
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.

--- a/wasm-lz4.c
+++ b/wasm-lz4.c
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-present, GM Cruise LLC
+//  Copyright (c) 2018-present, Cruise LLC
 //
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Cruise's corporate entity is now Cruise LLC and not GM Cruise LLC, so we are updating all the license headers to the appropriate name.